### PR TITLE
Fix off by 1 error in linear scale calculation

### DIFF
--- a/src/render_scale.py
+++ b/src/render_scale.py
@@ -213,7 +213,6 @@ class ScaleGen(inkex.Effect):
 				x = float(x) + self.labeloffseth
 				y = float(y) - self.labeloffsetv - font_height_offset
 
-			pos = n*self.res + fontsize/2
 			suffix = self.suffix  #.decode('utf-8') # fix ° (degree char)
 			text = etree.SubElement(group, inkex.addNS('text','svg'))
 
@@ -617,7 +616,7 @@ class ScaleGen(inkex.Effect):
 			self.scaleto, self.scalefrom = self.scalefrom+1, self.scaleto
 			
 		# calc resolution scale factor from external length and the scale distance
-		self.res = self.external_length / (self.scaleto - self.scalefrom)
+		self.res = self.external_length / (self.scaleto - self.scalefrom - 1)
 
 		if self.scaletype == 'straight':
 			for i in range(self.scalefrom, self.scaleto):


### PR DESCRIPTION
scaleTo += 1 was done due to python range being exclusive, it should not be applied when calculating range length.

Also remove unused code using `self.res`. 

To test:
* Have the document set up for mm
* enable 1mm grid
* Straight type
* outside length 100
* numberFrom 0, numberTo 10
* generate the scale
* position the scale so that 0 line is aligned with grid (snapping helps)

Before the change rest of the lines weren't aligned with grid and total length was wrong.
After the changes 10unit line is at 100mm, and all other lines are also aligned with grid.
 